### PR TITLE
(🎁) Preserve tilde when bumping

### DIFF
--- a/src/poetry_plugin_up/command.py
+++ b/src/poetry_plugin_up/command.py
@@ -134,11 +134,15 @@ class UpCommand(InstallerCommand):
             self.line(f"No new version for '{dependency.name}'")
             return
 
-        new_version = "^" + candidate.pretty_version
+        if (
+            dependency.pretty_constraint[0] == "~"
+            and "." in dependency.pretty_constraint
+        ):
+            new_version = "~" + candidate.pretty_version
+        else:
+            new_version = "^" + candidate.pretty_version
         if not latest:
-            if dependency.pretty_constraint[0] == "~":
-                new_version = "~" + candidate.pretty_version
-            elif dependency.pretty_constraint[:2] == ">=":
+            if dependency.pretty_constraint[:2] == ">=":
                 new_version = ">=" + candidate.pretty_version
 
         self.bump_version_in_pyproject_content(

--- a/tests/fixtures/simple_project/expected_pyproject_with_latest.toml
+++ b/tests/fixtures/simple_project/expected_pyproject_with_latest.toml
@@ -18,7 +18,7 @@ waldo = {git = "https://example.com/test/project.git"}
 [tool.poetry.group.dev.dependencies]
 fred = "1.1.1"
 plugh = "^2.2.2"
-xyzzy = "^2.2.2"
+xyzzy = "~2.2.2"
 nacho = "^2.2.2"
 thud = "^2.2.2"
 

--- a/tests/fixtures/simple_project/expected_pyproject_with_latest_and_pinned.toml
+++ b/tests/fixtures/simple_project/expected_pyproject_with_latest_and_pinned.toml
@@ -18,7 +18,7 @@ waldo = {git = "https://example.com/test/project.git"}
 [tool.poetry.group.dev.dependencies]
 fred = "^2.2.2"
 plugh = "^2.2.2"
-xyzzy = "^2.2.2"
+xyzzy = "~2.2.2"
 nacho = "^2.2.2"
 thud = "^2.2.2"
 


### PR DESCRIPTION
- Resolves #13

`"~1.1"` -> `"~2.2.2"`
`"~1"` ->  `"^2.2.2`"

The case of the dotless tilde (`~1` == `^1` == `>=1, <2`) is not handled in this case and is changed as before to a caret.