### PR TITLE
feat: add --preserve-wildcard

### DIFF
--- a/src/poetry_plugin_up/command.py
+++ b/src/poetry_plugin_up/command.py
@@ -59,6 +59,12 @@ class UpCommand(InstallerCommand):
             description="Output bumped <comment>pyproject.toml</> but do not "
             "execute anything.",
         ),
+        option(
+            long_name="preserve-wildcard",
+            short_name=None,
+            description="Do not bump wildcard dependencies "
+            "when updating to latest.",
+        ),
     ]
 
     def handle(self) -> int:
@@ -68,9 +74,16 @@ class UpCommand(InstallerCommand):
         no_install = self.option("no-install")
         dry_run = self.option("dry-run")
         exclude = self.option("exclude")
+        preserve_wildcard = self.option("preserve-wildcard")
 
         if pinned and not latest:
             self.line_error("'--pinned' specified without '--latest'")
+            raise Exception
+
+        if preserve_wildcard and not latest:
+            self.line_error(
+                "'--preserve-wildcard' specified without '--latest'"
+            )
             raise Exception
 
         selector = VersionSelector(self.poetry.pool)
@@ -87,6 +100,7 @@ class UpCommand(InstallerCommand):
                     pyproject_content=pyproject_content,
                     selector=selector,
                     exclude=exclude,
+                    preserve_wildcard=preserve_wildcard,
                 )
 
         if dry_run:
@@ -125,6 +139,7 @@ class UpCommand(InstallerCommand):
         pyproject_content: TOMLDocument,
         selector: VersionSelector,
         exclude: List[str],
+        preserve_wildcard: bool,
     ) -> None:
         """Handles a dependency"""
 
@@ -134,6 +149,7 @@ class UpCommand(InstallerCommand):
             latest,
             pinned,
             exclude,
+            preserve_wildcard,
         ):
             return
 
@@ -180,6 +196,7 @@ class UpCommand(InstallerCommand):
         latest: bool,
         pinned: bool,
         exclude: List[str],
+        preserve_wildcard: bool,
     ) -> bool:
         """Determines if a dependency can be bumped in pyproject.toml"""
 
@@ -193,6 +210,9 @@ class UpCommand(InstallerCommand):
             return False
 
         constraint = dependency.pretty_constraint
+        if preserve_wildcard and constraint == "*":
+            return False
+
         if not latest:
             if is_pinned(constraint):
                 # pinned

--- a/tests/fixtures/simple_project/expected_pyproject_with_latest_and_preserve_wildcard.toml
+++ b/tests/fixtures/simple_project/expected_pyproject_with_latest_and_preserve_wildcard.toml
@@ -1,0 +1,30 @@
+[tool.poetry]
+name = "simple-project"
+version = "1.2.3"
+description = "Some description."
+authors = ["Mousa Zeid Baker"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+foo = "^2.2.2"
+bar = "^2.2.2"
+baz = {version = "^2.2.2", extras = ["qux", "quux"]}
+corge = {version = "^2.2.2", optional = true}
+grault = {version = "^2.2.2", allow-prereleases = true}
+garply = {path = "./"}
+waldo = {git = "https://example.com/test/project.git"}
+
+[tool.poetry.group.dev.dependencies]
+fred = "1.1.1"
+plugh = "^2.2.2"
+xyzzy = "~2.2.2"
+nacho = "^2.2.2"
+thud = "^2.2.2"
+
+[tool.poetry.group.docs.dependencies]
+foobar = "^2.2.2"
+foobaz = "^2.2.2"
+fooqux = "^2.2.2"
+fooquux = "*"
+Foo_Corge = "^2.2.2"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -40,6 +40,7 @@ def test_handle_dependency(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        preserve_wildcard=False,
     )
 
     selector.find_best_candidate.assert_called_once_with(
@@ -87,6 +88,7 @@ def test_handle_dependency_with_latest(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        preserve_wildcard=False,
     )
 
     selector.find_best_candidate.assert_called_once_with(
@@ -134,6 +136,7 @@ def test_handle_dependency_with_zero_caret(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        preserve_wildcard=False,
     )
 
     selector.find_best_candidate.assert_called_once_with(
@@ -177,6 +180,46 @@ def test_handle_dependency_excluded(
         exclude=["foo"],
         pyproject_content=content,
         selector=selector,
+        preserve_wildcard=False,
+    )
+
+    selector.find_best_candidate.assert_not_called()
+    bump_version_in_pyproject_content.assert_not_called()
+
+
+def test_handle_dependency_preserve_wildcard(
+    up_cmd_tester: TestUpCommand,
+    mocker: MockerFixture,
+) -> None:
+    dependency = Dependency(
+        name="foo",
+        constraint="*",
+        groups=["main"],
+    )
+    new_version = "2.0.0"
+    package = Package(
+        name=dependency.name,
+        version=new_version,
+    )
+
+    content = parse("")
+
+    selector = Mock()
+    selector.find_best_candidate = Mock(return_value=package)
+    bump_version_in_pyproject_content = mocker.patch(
+        "poetry_plugin_up.command.UpCommand.bump_version_in_pyproject_content",
+        return_value=None,
+    )
+
+    up_cmd_tester.handle_dependency(
+        dependency=dependency,
+        latest=True,
+        pinned=False,
+        only_packages=[],
+        exclude=[],
+        pyproject_content=content,
+        selector=selector,
+        preserve_wildcard=True,
     )
 
     selector.find_best_candidate.assert_not_called()

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -117,6 +117,7 @@ def test_is_bumpable_is_false_when_source_type_is_git(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -135,6 +136,7 @@ def test_is_bumpable_is_false_when_source_type_is_file(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -153,6 +155,7 @@ def test_is_bumpable_is_false_when_source_type_is_directory(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -167,6 +170,7 @@ def test_is_bumpable_is_false_when_name_is_python(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -181,6 +185,7 @@ def test_is_bumpable_is_false_when_dependency_not_in_only_packages(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -198,6 +203,7 @@ def test_is_bumpable_is_false_when_version_pinned(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -215,6 +221,7 @@ def test_is_bumpable_is_false_when_version_wildcard(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -232,6 +239,7 @@ def test_is_bumpable_is_false_when_version_less_than(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -249,6 +257,7 @@ def test_is_bumpable_is_false_when_version_greater_than(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -266,6 +275,7 @@ def test_is_bumpable_is_false_when_version_less_than_or_equal(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -283,6 +293,7 @@ def test_is_bumpable_is_false_when_version_inequality(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -300,6 +311,7 @@ def test_is_bumpable_is_false_when_version_multiple_requirements(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -317,6 +329,7 @@ def test_is_bumpable_is_true_when_version_caret(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -334,6 +347,7 @@ def test_is_bumpable_is_true_when_version_tilde(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -351,6 +365,7 @@ def test_is_bumpable_is_true_when_version_greater_than_or_equal(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -368,6 +383,7 @@ def test_is_bumpable_is_true_when_version_tilde_pep440(
         latest=False,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -385,6 +401,7 @@ def test_is_bumpable_is_false_when_version_pinned_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -402,6 +419,7 @@ def test_is_bumpable_is_true_when_version_pinned_and_latest_and_pinned(
         latest=True,
         pinned=True,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -427,6 +445,7 @@ def test_is_bumpable_is_false_when_version_pinned_with_with_equals_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False
 
@@ -444,6 +463,7 @@ def test_is_bumpable_is_true_when_version_wildcard_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -461,6 +481,7 @@ def test_is_bumpable_is_true_when_version_less_than_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -478,6 +499,7 @@ def test_is_bumpable_is_true_when_version_greater_than_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -495,6 +517,7 @@ def test_is_bumpable_is_true_when_version_less_than_or_equal_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        preserve_wildcard=False,
     )
     assert is_bumpable is True
 
@@ -512,5 +535,24 @@ def test_is_bumpable_is_false_when_dependency_excluded(
         latest=True,
         pinned=False,
         exclude=["foo"],
+        preserve_wildcard=False,
+    )
+    assert is_bumpable is False
+
+
+def test_is_bumpable_is_false_when_preserve_wildcard(
+    up_cmd_tester: TestUpCommand,
+) -> None:
+    dependency = Dependency(
+        name="foo",
+        constraint="*",
+    )
+    is_bumpable = up_cmd_tester.is_bumpable(
+        dependency=dependency,
+        only_packages=[],
+        latest=True,
+        pinned=False,
+        exclude=["foo"],
+        preserve_wildcard=False,
     )
     assert is_bumpable is False


### PR DESCRIPTION
Hi! I want to suggest you a couple of improvements:
- Add a new option --preserve-wildcard. It would be useful to left wildcard dependencies unchanged
- Do not replace inequality requirements with caret

What do you think?