### PR TITLE
upgrade pip dependencies and checkout action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
     environment: ${{ matrix.environment }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -953,13 +953,13 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-mock"
-version = "3.11.1"
+version = "3.12.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
-    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
+    {file = "pytest-mock-3.12.0.tar.gz", hash = "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"},
+    {file = "pytest_mock-3.12.0-py3-none-any.whl", hash = "sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f"},
 ]
 
 [package.dependencies]
@@ -1259,24 +1259,24 @@ files = [
 
 [[package]]
 name = "trove-classifiers"
-version = "2023.9.19"
+version = "2023.10.18"
 description = "Canonical source for classifiers on PyPI (pypi.org)."
 optional = false
 python-versions = "*"
 files = [
-    {file = "trove-classifiers-2023.9.19.tar.gz", hash = "sha256:3e700af445c802f251ce2b741ee78d2e5dfa5ab8115b933b89ca631b414691c9"},
-    {file = "trove_classifiers-2023.9.19-py3-none-any.whl", hash = "sha256:55460364fe248294386d4dfa5d16544ec930493ecc6bd1db07a0d50afb37018e"},
+    {file = "trove-classifiers-2023.10.18.tar.gz", hash = "sha256:2cdfcc7f31f7ffdd57666a9957296089ac72daad4d11ab5005060e5cd7e29939"},
+    {file = "trove_classifiers-2023.10.18-py3-none-any.whl", hash = "sha256:20a3da8e3cb65587cc9f5d5b837bf74edeb480bba9bd8cd4f03ab056d6b06c4c"},
 ]
 
 [[package]]
 name = "urllib3"
-version = "2.0.6"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.6-py3-none-any.whl", hash = "sha256:7a7c7003b000adf9e7ca2a377c9688bbc54ed41b985789ed576570342a375cd2"},
-    {file = "urllib3-2.0.6.tar.gz", hash = "sha256:b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
@@ -1407,4 +1407,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "fb400a5e63487d45554d87408690edc59979b7a2832115fd966634e991603c88"
+content-hash = "a163088dedb41d49bbeb3e0e001c59a2ec15f5a8ff30ca8b7ed009b8990b46be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-poetry = "^1.6.0"
+poetry = "^1.6.1"
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "^2.20.0"
-pytest = "^7.2.0"
-pytest-mock = "^3.10.0"
+pre-commit = "^2.21.0"
+pytest = "^7.4.2"
+pytest-mock = "^3.12.0"
 
 [tool.poetry.plugins."poetry.application.plugin"]
 up = "poetry_plugin_up.plugin:UpApplicationPlugin"


### PR DESCRIPTION
Hi @MousaZeidBaker,
I just received a notification about the latest release of this project. I was surprised to notice that apparently some of the dependencies are **outdated**. So I used the plugin to upgrade it's dependencies.

I also thought about adding a Dependabot config file. But apparently there's no option yet to exclude the `tests/` directory. So Dependabot would likely try overwrite the test data regularly by opening pull requests.
Maybe executing the plugin in CI workflow and using Dependabot only for the GitHub Actions might be a feasable alternative.

```yaml
name: Upgrade pip dependencies

on:
  schedule:
   # every Monday at 05:05AM
   - cron: "5 5 * * 1"

jobs:
  upgrade:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@v3
        with:
          fetch-depth: 0

      - name: Setup Python 3.11
        uses: actions/setup-python@v4
        with:
          python-version: "3.11"

      - name: Install poetry
        uses: snok/install-poetry@v1
        with:
          version: 1.6.0

      - name: Install dependencies
        run: poetry install

      - name: Build
        run: poetry build

      - name: Upgrade dependencies
        run: poetry up

      # ... open a pull request if changes have been detected ...
```


Hope this PR might be helpful to you. I'd be very grateful if you could share your feedback below.
Regards,
Adrian