### PR TITLE
Don't install LICENSE in the Python path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers=[
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-include = ["LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
poetry-plugin-up install its license in the Python path (e.g., https://archlinux.org/packages/extra/any/python-poetry-plugin-up/). This may cause install failure.