### PR TITLE
feat: add option to include zero based carets dependencies

### DIFF
--- a/src/poetry_plugin_up/command.py
+++ b/src/poetry_plugin_up/command.py
@@ -218,7 +218,10 @@ class UpCommand(InstallerCommand):
             return False
         if dependency.name in exclude:
             return False
-        if exclude_zero_based_caret and dependency.pretty_constraint.startswith("^0"):
+        if (
+            exclude_zero_based_caret
+            and dependency.pretty_constraint.startswith("^0")
+        ):
             return False
 
         constraint = dependency.pretty_constraint

--- a/src/poetry_plugin_up/command.py
+++ b/src/poetry_plugin_up/command.py
@@ -41,6 +41,11 @@ class UpCommand(InstallerCommand):
             ),
         ),
         option(
+            long_name="zero-based-carets",
+            short_name=None,
+            description="Include zero based carets dependencies.",
+        ),
+        option(
             long_name="exclude",
             short_name=None,
             description="Exclude dependencies.",
@@ -71,6 +76,7 @@ class UpCommand(InstallerCommand):
         only_packages = self.argument("packages")
         latest = self.option("latest")
         pinned = self.option("pinned")
+        zero_based_carets = self.option("zero-based-carets")
         no_install = self.option("no-install")
         dry_run = self.option("dry-run")
         exclude = self.option("exclude")
@@ -96,6 +102,7 @@ class UpCommand(InstallerCommand):
                     dependency=dependency,
                     latest=latest,
                     pinned=pinned,
+                    zero_based_carets=zero_based_carets,
                     only_packages=only_packages,
                     pyproject_content=pyproject_content,
                     selector=selector,
@@ -135,6 +142,7 @@ class UpCommand(InstallerCommand):
         dependency: Dependency,
         latest: bool,
         pinned: bool,
+        zero_based_carets: bool,
         only_packages: List[str],
         pyproject_content: TOMLDocument,
         selector: VersionSelector,
@@ -169,7 +177,11 @@ class UpCommand(InstallerCommand):
 
         # preserve zero based carets ('^0.0') when bumping
         version = re.match(r"\^([0.]+)", dependency.pretty_constraint)
-        if version and candidate.pretty_version.startswith(version[1]):
+        if (
+            not zero_based_carets
+            and version
+            and candidate.pretty_version.startswith(version[1])
+        ):
             return
 
         if (

--- a/src/poetry_plugin_up/command.py
+++ b/src/poetry_plugin_up/command.py
@@ -41,11 +41,6 @@ class UpCommand(InstallerCommand):
             ),
         ),
         option(
-            long_name="zero-based-carets",
-            short_name=None,
-            description="Include zero based carets dependencies.",
-        ),
-        option(
             long_name="exclude",
             short_name=None,
             description="Exclude dependencies.",
@@ -76,7 +71,6 @@ class UpCommand(InstallerCommand):
         only_packages = self.argument("packages")
         latest = self.option("latest")
         pinned = self.option("pinned")
-        zero_based_carets = self.option("zero-based-carets")
         no_install = self.option("no-install")
         dry_run = self.option("dry-run")
         exclude = self.option("exclude")
@@ -102,7 +96,6 @@ class UpCommand(InstallerCommand):
                     dependency=dependency,
                     latest=latest,
                     pinned=pinned,
-                    zero_based_carets=zero_based_carets,
                     only_packages=only_packages,
                     pyproject_content=pyproject_content,
                     selector=selector,
@@ -142,7 +135,6 @@ class UpCommand(InstallerCommand):
         dependency: Dependency,
         latest: bool,
         pinned: bool,
-        zero_based_carets: bool,
         only_packages: List[str],
         pyproject_content: TOMLDocument,
         selector: VersionSelector,
@@ -177,11 +169,7 @@ class UpCommand(InstallerCommand):
 
         # preserve zero based carets ('^0.0') when bumping
         version = re.match(r"\^([0.]+)", dependency.pretty_constraint)
-        if (
-            not zero_based_carets
-            and version
-            and candidate.pretty_version.startswith(version[1])
-        ):
+        if version and candidate.pretty_version.startswith(version[1]):
             return
 
         if (

--- a/src/poetry_plugin_up/command.py
+++ b/src/poetry_plugin_up/command.py
@@ -182,14 +182,6 @@ class UpCommand(InstallerCommand):
             self.line(f"No new version for '{dependency.name}'")
             return
 
-<<<<<<< Updated upstream
-        # preserve zero based carets ('^0.0') when bumping
-        version = re.match(r"\^([0.]+)", dependency.pretty_constraint)
-        if version and candidate.pretty_version.startswith(version[1]):
-            return
-
-=======
->>>>>>> Stashed changes
         if (
             dependency.pretty_constraint[0] == "~"
             and "." in dependency.pretty_constraint

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -179,6 +179,12 @@ def test_command_with_exclude(
     command_call.assert_called_once_with(name="update")
 
 
+def test_exclude_zero_based_caret_without_latest_fails(
+    app_tester: ApplicationTester,
+) -> None:
+    assert app_tester.execute("up --exclude-zero-based-caret") == 1
+
+
 def test_command_preserve_wildcard(
     app_tester: ApplicationTester,
     packages: List[Package],

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -36,6 +36,7 @@ def test_handle_dependency(
         dependency=dependency,
         latest=False,
         pinned=False,
+        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,
@@ -84,6 +85,7 @@ def test_handle_dependency_with_latest(
         dependency=dependency,
         latest=True,
         pinned=True,
+        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,
@@ -132,6 +134,7 @@ def test_handle_dependency_with_zero_caret(
         dependency=dependency,
         latest=True,
         pinned=False,
+        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,
@@ -146,6 +149,55 @@ def test_handle_dependency_with_zero_caret(
         source=dependency.source_name,
     )
     bump_version_in_pyproject_content.assert_not_called()
+
+
+def test_handle_dependency_with_zero_caret_when_included(
+    up_cmd_tester: TestUpCommand,
+    mocker: MockerFixture,
+) -> None:
+    dependency = Dependency(
+        name="foo",
+        constraint="^0",
+        groups=["main"],
+    )
+    new_version = "0.1"
+    package = Package(
+        name=dependency.name,
+        version=new_version,
+    )
+
+    content = parse("")
+
+    selector = Mock()
+    selector.find_best_candidate = Mock(return_value=package)
+    bump_version_in_pyproject_content = mocker.patch(
+        "poetry_plugin_up.command.UpCommand.bump_version_in_pyproject_content",
+        return_value=None,
+    )
+
+    up_cmd_tester.handle_dependency(
+        dependency=dependency,
+        latest=True,
+        pinned=False,
+        zero_based_carets=True,
+        only_packages=[],
+        exclude=[],
+        pyproject_content=content,
+        selector=selector,
+        preserve_wildcard=False,
+    )
+
+    selector.find_best_candidate.assert_called_once_with(
+        package_name=dependency.name,
+        target_package_version="*",
+        allow_prereleases=dependency.allows_prereleases(),
+        source=dependency.source_name,
+    )
+    bump_version_in_pyproject_content.assert_called_once_with(
+        dependency=dependency,
+        new_version=f"^{new_version}",
+        pyproject_content=content,
+    )
 
 
 def test_handle_dependency_excluded(
@@ -176,6 +228,7 @@ def test_handle_dependency_excluded(
         dependency=dependency,
         latest=False,
         pinned=False,
+        zero_based_carets=False,
         only_packages=[],
         exclude=["foo"],
         pyproject_content=content,
@@ -215,6 +268,7 @@ def test_handle_dependency_preserve_wildcard(
         dependency=dependency,
         latest=True,
         pinned=False,
+        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -40,6 +40,7 @@ def test_handle_dependency(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
 
@@ -88,6 +89,7 @@ def test_handle_dependency_with_latest(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
 
@@ -136,15 +138,11 @@ def test_handle_dependency_with_zero_caret(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        exclude_zero_based_caret=True,
         preserve_wildcard=False,
     )
 
-    selector.find_best_candidate.assert_called_once_with(
-        package_name=dependency.name,
-        target_package_version="*",
-        allow_prereleases=dependency.allows_prereleases(),
-        source=dependency.source_name,
-    )
+    selector.find_best_candidate.assert_not_called()
     bump_version_in_pyproject_content.assert_not_called()
 
 
@@ -180,6 +178,7 @@ def test_handle_dependency_excluded(
         exclude=["foo"],
         pyproject_content=content,
         selector=selector,
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
 
@@ -219,6 +218,7 @@ def test_handle_dependency_preserve_wildcard(
         exclude=[],
         pyproject_content=content,
         selector=selector,
+        exclude_zero_based_caret=False,
         preserve_wildcard=True,
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -36,7 +36,6 @@ def test_handle_dependency(
         dependency=dependency,
         latest=False,
         pinned=False,
-        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,
@@ -85,7 +84,6 @@ def test_handle_dependency_with_latest(
         dependency=dependency,
         latest=True,
         pinned=True,
-        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,
@@ -134,7 +132,6 @@ def test_handle_dependency_with_zero_caret(
         dependency=dependency,
         latest=True,
         pinned=False,
-        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,
@@ -149,55 +146,6 @@ def test_handle_dependency_with_zero_caret(
         source=dependency.source_name,
     )
     bump_version_in_pyproject_content.assert_not_called()
-
-
-def test_handle_dependency_with_zero_caret_when_included(
-    up_cmd_tester: TestUpCommand,
-    mocker: MockerFixture,
-) -> None:
-    dependency = Dependency(
-        name="foo",
-        constraint="^0",
-        groups=["main"],
-    )
-    new_version = "0.1"
-    package = Package(
-        name=dependency.name,
-        version=new_version,
-    )
-
-    content = parse("")
-
-    selector = Mock()
-    selector.find_best_candidate = Mock(return_value=package)
-    bump_version_in_pyproject_content = mocker.patch(
-        "poetry_plugin_up.command.UpCommand.bump_version_in_pyproject_content",
-        return_value=None,
-    )
-
-    up_cmd_tester.handle_dependency(
-        dependency=dependency,
-        latest=True,
-        pinned=False,
-        zero_based_carets=True,
-        only_packages=[],
-        exclude=[],
-        pyproject_content=content,
-        selector=selector,
-        preserve_wildcard=False,
-    )
-
-    selector.find_best_candidate.assert_called_once_with(
-        package_name=dependency.name,
-        target_package_version="*",
-        allow_prereleases=dependency.allows_prereleases(),
-        source=dependency.source_name,
-    )
-    bump_version_in_pyproject_content.assert_called_once_with(
-        dependency=dependency,
-        new_version=f"^{new_version}",
-        pyproject_content=content,
-    )
 
 
 def test_handle_dependency_excluded(
@@ -228,7 +176,6 @@ def test_handle_dependency_excluded(
         dependency=dependency,
         latest=False,
         pinned=False,
-        zero_based_carets=False,
         only_packages=[],
         exclude=["foo"],
         pyproject_content=content,
@@ -268,7 +215,6 @@ def test_handle_dependency_preserve_wildcard(
         dependency=dependency,
         latest=True,
         pinned=False,
-        zero_based_carets=False,
         only_packages=[],
         exclude=[],
         pyproject_content=content,

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -117,6 +117,7 @@ def test_is_bumpable_is_false_when_source_type_is_git(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -136,6 +137,7 @@ def test_is_bumpable_is_false_when_source_type_is_file(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -155,6 +157,7 @@ def test_is_bumpable_is_false_when_source_type_is_directory(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -170,6 +173,7 @@ def test_is_bumpable_is_false_when_name_is_python(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -185,6 +189,7 @@ def test_is_bumpable_is_false_when_dependency_not_in_only_packages(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -203,6 +208,7 @@ def test_is_bumpable_is_false_when_version_pinned(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -221,6 +227,7 @@ def test_is_bumpable_is_false_when_version_wildcard(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -239,6 +246,7 @@ def test_is_bumpable_is_false_when_version_less_than(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -257,6 +265,7 @@ def test_is_bumpable_is_false_when_version_greater_than(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -275,6 +284,7 @@ def test_is_bumpable_is_false_when_version_less_than_or_equal(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -293,6 +303,7 @@ def test_is_bumpable_is_false_when_version_inequality(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -311,6 +322,7 @@ def test_is_bumpable_is_false_when_version_multiple_requirements(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -329,6 +341,7 @@ def test_is_bumpable_is_true_when_version_caret(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -347,6 +360,7 @@ def test_is_bumpable_is_true_when_version_tilde(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -365,6 +379,7 @@ def test_is_bumpable_is_true_when_version_greater_than_or_equal(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -383,6 +398,7 @@ def test_is_bumpable_is_true_when_version_tilde_pep440(
         latest=False,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -401,6 +417,7 @@ def test_is_bumpable_is_false_when_version_pinned_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -419,6 +436,7 @@ def test_is_bumpable_is_true_when_version_pinned_and_latest_and_pinned(
         latest=True,
         pinned=True,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -445,6 +463,7 @@ def test_is_bumpable_is_false_when_version_pinned_with_with_equals_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -463,6 +482,7 @@ def test_is_bumpable_is_true_when_version_wildcard_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -481,6 +501,7 @@ def test_is_bumpable_is_true_when_version_less_than_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -499,6 +520,7 @@ def test_is_bumpable_is_true_when_version_greater_than_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -517,6 +539,7 @@ def test_is_bumpable_is_true_when_version_less_than_or_equal_and_latest(
         latest=True,
         pinned=False,
         exclude=[],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is True
@@ -535,6 +558,26 @@ def test_is_bumpable_is_false_when_dependency_excluded(
         latest=True,
         pinned=False,
         exclude=["foo"],
+        exclude_zero_based_caret=False,
+        preserve_wildcard=False,
+    )
+    assert is_bumpable is False
+
+
+def test_is_bumpable_is_false_when_exclude_zero_based_caret(
+    up_cmd_tester: TestUpCommand,
+) -> None:
+    dependency = Dependency(
+        name="foo",
+        constraint="^0.2.3",
+    )
+    is_bumpable = up_cmd_tester.is_bumpable(
+        dependency=dependency,
+        only_packages=[],
+        latest=True,
+        pinned=False,
+        exclude=["foo"],
+        exclude_zero_based_caret=True,
         preserve_wildcard=False,
     )
     assert is_bumpable is False
@@ -553,6 +596,7 @@ def test_is_bumpable_is_false_when_preserve_wildcard(
         latest=True,
         pinned=False,
         exclude=["foo"],
+        exclude_zero_based_caret=False,
         preserve_wildcard=False,
     )
     assert is_bumpable is False


### PR DESCRIPTION
By default, the plugin ignores zero-based carets. But this option to update them too will be useful for many popular packages that are still `0.*.*` version. For example `fastapi` or `uvicorn`.

Closes #41 